### PR TITLE
Unit test company manage fail cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /storage/*.key
 /vendor
 .env
+.env.testing
 .env.backup
 env/
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -38,14 +38,29 @@ docker-compose -f docker-compose.local.yml up
 ```bash
 docker restart sit-careers-composer
 ```
-If you face error `PermissionError on db folder` Please use
-```bash
-sudo chown -R $USER:$USER db/
-```
 If you want to exec to container api use
 ```bash
 docker exec -it sit-careers-api bash
 ```
+###### Testing on local
+1. Copy .env.example to .env.testing and Change database
+```bash
+cp .env.example .env
 
+DB_HOST=db
+DB_DATABASE=sitcareers_testing
+```
+> Don't forget update DB_PASSWORD
+
+2. Exec to container api
+```bash
+docker exec -it sit-careers-api bash
+```
+3. Run test
+```bash
+php artisan test --env=testing
+```
+
+> Note: DB_DATABASE on local have 2 databases: `sitcareers`, `sitcareers_testing`
 -----
 Enjoy !! ✌

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker exec -it sit-careers-api bash
 ###### Testing on local
 1. Copy .env.example to .env.testing and Change database
 ```bash
-cp .env.example .env
+cp .env.example .env.testing
 
 DB_HOST=db
 DB_DATABASE=sitcareers_testing

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -38,10 +38,12 @@ services:
     image: mariadb:latest
     restart: always
     container_name: sit-careers-db
-    volumes:
-        - ./db:/var/lib/mysql
     ports:
         - "3306:3306"
+    entrypoint:
+      sh -c "
+        echo 'CREATE DATABASE sitcareers_testing;' > /docker-entrypoint-initdb.d/init.sql;
+        /usr/local/bin/docker-entrypoint.sh --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
     environment:
         MYSQL_DATABASE: sitcareers
         MYSQL_ROOT_PASSWORD: root

--- a/tests/Unit/CompanyTest.php
+++ b/tests/Unit/CompanyTest.php
@@ -28,7 +28,7 @@ class CompanyTest extends TestCase
     public function test_post_company_success_should_return_company()
     {
         $data = [
-            'company_id' => $this->faker->company_id, 
+            'company_id' => $this->faker->company_id,
             'company_name_th' => 'บริษัท เทส จำกัด',
             'company_name_en' => 'Test COmpany',
             'description' => 'เป็นบริษัทพัฒนา software บริษัทใหญ่ อยู่เยอรมัน',
@@ -56,10 +56,10 @@ class CompanyTest extends TestCase
             "mou_link" => "https://www.google.co.th",
             "contact_period" => "30 กันยายน 2563 - 30 กันยายน 2565"
         ];
-        
+
         $response = $this->postJson('api/company', $data);
         $response->assertStatus(200);
-        
+
         $response_arr = json_decode($response->content(), true);
         $company = Company::find($response_arr['company_id']);
         $company_arr = $company->toArray()['company_id'];
@@ -110,7 +110,7 @@ class CompanyTest extends TestCase
 
         $response = $this->putJson('api/company', $data);
         $response->assertStatus(200);
-        
+
         $response_arr = json_decode($response->content(), true);
         $company = Company::find($response_arr['company_id']);
         $company_arr = $company->toArray();
@@ -118,5 +118,15 @@ class CompanyTest extends TestCase
         // Check field that are changed
         $this->assertEquals($company_arr['company_id'], $response_arr['company_id']);
         $this->assertEquals($company_arr['company_name_th'], $response_arr['company_name_th']);
+    }
+
+    public function test_post_company_fail_should_return_status_500 ()
+    {
+        $data = [
+            'company_id' => $this->faker->company_id
+        ];
+
+        $response = $this->postJson('api/company', $data);
+        $response->assertStatus(500);
     }
 }

--- a/tests/Unit/CompanyTest.php
+++ b/tests/Unit/CompanyTest.php
@@ -122,11 +122,28 @@ class CompanyTest extends TestCase
 
     public function test_post_company_fail_should_return_status_500 ()
     {
+        $data = [];
+
+        $response = $this->postJson('api/company', $data);
+        $response->assertStatus(500);
+    }
+
+    public function test_update_company_fail_should_return_status_500()
+    {
+        $address = factory(Address::class)->create([
+            "company_id" => $this->faker->company_id,
+            "address_id" => Uuid::uuid()
+        ]);
+        $mou = factory(MOU::class)->create([
+            "company_id" => $this->faker->company_id,
+            "mou_id" => Uuid::uuid()
+        ]);
+
         $data = [
             'company_id' => $this->faker->company_id
         ];
 
-        $response = $this->postJson('api/company', $data);
+        $response = $this->putJson('api/company', $data);
         $response->assertStatus(500);
     }
 }


### PR DESCRIPTION
Connect to card https://trello.com/c/yvBQ55tE/39-%F0%9F%A7%A1-sp2-write-unittest-for-failing-for-api
- Update post company fail case.
- Add update company fail case.

Update local docker compose to create test database name: `sitcareers_testing`
- Improve database for local .
- Update README.md.