### PR TITLE
Update status announcement

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -9,7 +9,7 @@ use App\Traits\AnnouncementsExport;
 use App\Traits\CompaniesExport;
 use App\Repositories\DashboardRepositoryInterface;
 use App\Traits\DashboardExport;
-use Carbon\Carbon;
+use App\Traits\Utils;
 use Illuminate\Http\Request;
 use Maatwebsite\Excel\Facades\Excel;
 use Throwable;
@@ -17,6 +17,7 @@ use Throwable;
 class DashboardController extends Controller
 {
     use DashboardRules;
+    use Utils;
     private $dashboard;
 
     public function __construct(DashboardRepositoryInterface $dashboard_repo)
@@ -90,6 +91,7 @@ class DashboardController extends Controller
             if ($validated->fails()){
                 return response()->json($validated->messages(), 400);
             }
+            $check_due_date = $this->checkDueDateForAnnouncement();
 
             $file_name = 'announcements'. '_' . $data['start_date'] . '-' . $data['end_date'] . '.xlsx';
             $path = '/reports/announcements/';
@@ -106,7 +108,8 @@ class DashboardController extends Controller
 
         return response()->json([
             "message" => $path_file_name,
-            "status_uploaded_file" => $announcements_excel
+            "status_uploaded_file" => $announcements_excel,
+            "status_update_expire" => $check_due_date
         ], 200
         );
     }

--- a/app/Traits/Utils.php
+++ b/app/Traits/Utils.php
@@ -3,6 +3,7 @@
 
 namespace App\Traits;
 
+use App\Models\Announcement;
 use Carbon\Carbon;
 
 use Illuminate\Support\Str;
@@ -13,5 +14,21 @@ trait Utils
     public function checkDateToDayBetweenStartAndEnd($data)
     {
         return Carbon::now()->between($data['start_date'], $data['end_date']);
+    }
+
+    public function checkDueDateForAnnouncement()
+    {
+        $announcements = Announcement::get();
+        for($i=0; $i < count($announcements); $i++){
+            $announcement = $announcements[$i];
+            if(!$this->checkDateToDayBetweenStartAndEnd($announcement)){
+                $announcement->status = 'CLOSE';
+                $announcement->save();
+                $message = 'Expired announcements have been updated status';
+            }else {
+                $message = 'Not have expired announcements';
+            }
+        }
+        return $message;
     }
 }

--- a/tests/Unit/DashboardTest.php
+++ b/tests/Unit/DashboardTest.php
@@ -82,10 +82,9 @@ class DashboardTest extends TestCase
         Excel::fake();
 
         $data = [
-            'start_date' => '2021-02-19',
-            'end_date' => '2021-02-24'
+            'start_date' => '2021-03-19',
+            'end_date' => Carbon::now()->addDays(5)->format('Y-m-d')
         ];
-
         $response = $this->call('GET', 'api/dashboard/announcements/export', $data);
 
         $file_name = 'announcements'. '_' . $data['start_date'] . '-' . $data['end_date'] . '.xlsx';


### PR DESCRIPTION
Connect to card https://trello.com/c/wGPulDuJ/151-%F0%9F%A7%A1-sp3-update-status-of-announcement-in-the-table-when-download-report

- Add check expired date for announcement before export
- Update date of mockdata

Note: status ของ announcement จะถูก update ก็ต่อเมื่อมีการยิงเพื่อ export .xlsx ของ annoucement 